### PR TITLE
Change uri to api.crowdin.com

### DIFF
--- a/src/Crowdin.php
+++ b/src/Crowdin.php
@@ -53,7 +53,7 @@ class Crowdin
 	 *
 	 * @since    1.0
 	 */
-	public function __construct($projectId, $apiKey, $baseUri = 'http://api.crowdin.net/api/', HttpClient $client = null)
+	public function __construct($projectId, $apiKey, $baseUri = 'http://api.crowdin.com/api/', HttpClient $client = null)
 	{
 		$this->projectId = $projectId;
 		$this->apiKey = $apiKey;

--- a/src/Crowdin.php
+++ b/src/Crowdin.php
@@ -53,7 +53,7 @@ class Crowdin
 	 *
 	 * @since    1.0
 	 */
-	public function __construct($projectId, $apiKey, $baseUri = 'http://api.crowdin.com/api/', HttpClient $client = null)
+	public function __construct($projectId, $apiKey, $baseUri = 'https://api.crowdin.com/api/', HttpClient $client = null)
 	{
 		$this->projectId = $projectId;
 		$this->apiKey = $apiKey;


### PR DESCRIPTION
Crowdin company received me an email some days ago with next text:

>In a week, we're planning to perform a redirect to https://api.crowdin.com when the request is sent to http://api.crowdin.net or https://api.crowdin.net . It should not cause any issues with API communication, but still that would be great if you could verify your current configuration

> On July 25th, http://api.crowdin.net and https://api.crowdin.net are planned to be competely disabled and thus it's strongly recommended to switch to https://api.crowdin.com beforehand to prevent any pauses with your Crowdin integration. Kindly check this inquiry with your development team